### PR TITLE
Update react-tour.page.server.mdx

### DIFF
--- a/pages/react-tour.page.server.mdx
+++ b/pages/react-tour.page.server.mdx
@@ -109,7 +109,7 @@ async function render(pageContext) {
 我们可以创建一个默认应用到所有页面的 `/renderer/_default.page.client.js` 和 `/renderer/_default.page.server.js`
 
 实际上我们最后创建的两个文件是 `/renderer/_default.page.client.js` 和 `/renderer/_default.page.server.js`
-这意味着我们可以通过定义一个新的 `.page.vue` 文件来创建一个新的页面（`.page.route.js`文件是可选的）
+这意味着我们可以通过定义一个新的 `.page.jsx` 文件来创建一个新的页面（`.page.route.js`文件是可选的）
 
 `_default.page.` 文件可以被覆盖。比如，我们可以在一些页面中使用不同的 UI 框架（如 Vue）覆盖 `render()` hook
 


### PR DESCRIPTION
React集成教程中，文件后缀问题，
https://github.com/brillout/vite-plugin-ssr/blob/81210291d669b50c8bb7fce290c118e7594bc5bd/docs/pages/react-tour.page.server.mdx?plain=1#L109

React示例文件为`page.jsx`，非`page.vue`